### PR TITLE
Resolve d.body when getbyid with stale cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,13 @@ Cache.prototype.getById = function(type, id, fn, params, options) {
     }
   }
 
-  return this.get(fn, params, options);
+  var cache = this;
+
+  return new Promise(function(resolve, reject) {
+    cache.get(fn, params, options).then(function(d){
+      resolve(d.body)
+    }, reject);
+  });
 };
 
 


### PR DESCRIPTION
Makes the logic match when getting with a stale cache, and without.